### PR TITLE
Updated Commands to Retrieve and Set Display ID on scrcpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Step 4. Run create-app.sh:
 $ chmod +x ./create-app.sh
 $ ./create-app.sh WindowName Width Height Package Activity
 ```
-	WindowName: name of the window to be displayed in title bar
+	    WindowName: name of the window to be displayed in title bar
+  	    Width: width of app window and of the virtual screen that will be
+	            used
  	    Height: height of app window and of the virtual screen that will be
 	            used
 	            Take note that 40px at the top will be cut to immerse
 	            android titlebar with linux one
-	     Width: width of app window and of the virtual screen that will be
-	            used
 	   Package: package name of the app, e.g. com.android.launcher3
 	  Activity: name of the activity that will be started.
 	            Not all activities are supported.

--- a/create-app.sh
+++ b/create-app.sh
@@ -7,9 +7,9 @@ let GW=$2;
 let GH=$3;
 
 adb shell settings put global overlay_display_devices \${GW}x\${GH}/200;
-let PhoneDisplay=\$(scrcpy -V error --display=255 | grep -so "\-\-display [0-9]*" | grep -v "\-\-display 0" | grep -o "[0-9]*");
-adb shell wm size reset -d \$PhoneDisplay;
-adb shell am start-activity --windowingMode 6 --display \$PhoneDisplay $4/$5; scrcpy --display \$PhoneDisplay --window-title $1 --crop \$GW:\$GH:0:40 && adb shell settings put global overlay_display_devices none && adb shell input keyevent HOME
+let PhoneDisplay=\$(scrcpy --list-displays | grep -soe "--display-id=[0-9]*" | grep -soe "[0-9]*" | tail -n1);
+adb shell wm size reset -d \${PhoneDisplay};
+adb shell am start-activity --windowingMode 6 --display \${PhoneDisplay} $4/$5; scrcpy --display-id=\${PhoneDisplay} --window-title $1 --crop \${GW}:\${GH}:0:40 && adb shell settings put global overlay_display_devices none && adb shell input keyevent HOME
 EOF
 
 chmod +x $1.sh


### PR DESCRIPTION
Instead of retrieving the new display id by triggering a scrcpy error, use --list-displays instead.
Simplified grep and regex pipes
Set display id using new --display-id attribute instead of deprecated --display  in scrcpy launch
Minor change in readme.